### PR TITLE
Add iOS and Android Unity pause/resume functions

### DIFF
--- a/android/src/main/java/com/reactnative/unity/view/UnityViewManager.java
+++ b/android/src/main/java/com/reactnative/unity/view/UnityViewManager.java
@@ -19,6 +19,8 @@ public class UnityViewManager extends SimpleViewManager<UnityView> implements Li
     private static final String REACT_CLASS = "UnityView";
 
     public static final int COMMAND_POST_MESSAGE = 1;
+    public static final int COMMAND_PAUSE = 2;
+    public static final int COMMAND_RESUME = 3;
 
     private ReactApplicationContext context;
 
@@ -36,7 +38,9 @@ public class UnityViewManager extends SimpleViewManager<UnityView> implements Li
     @Override
     public @Nullable Map<String, Integer> getCommandsMap() {
         return MapBuilder.of(
-                "postMessage", COMMAND_POST_MESSAGE
+                "postMessage", COMMAND_POST_MESSAGE,
+                "pause", COMMAND_PAUSE,
+                "resume", COMMAND_RESUME
         );
     }
 
@@ -49,6 +53,12 @@ public class UnityViewManager extends SimpleViewManager<UnityView> implements Li
                 String message = args.getString(2);
                 UnityUtils.postMessage(gameObject, methodName, message);
                 break;
+            case COMMAND_PAUSE:
+                UnityUtils.getPlayer().pause();
+                break;
+            case COMMAND_RESUME:
+                UnityUtils.getPlayer().resume();
+                break;                
         }
     }
 

--- a/ios/RNUnityViewManager.m
+++ b/ios/RNUnityViewManager.m
@@ -84,4 +84,14 @@ RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag gameObject:(NSString 
     UnityPostMessage(gameObject, methodName, message);
 }
 
+RCT_EXPORT_METHOD(pause:(nonnull NSNumber *)reactTag)
+{
+    UnityPauseCommand();
+}
+
+RCT_EXPORT_METHOD(resume:(nonnull NSNumber *)reactTag)
+{
+    UnityResumeCommand();
+}
+
 @end

--- a/ios/UnityUtils.h
+++ b/ios/UnityUtils.h
@@ -13,6 +13,10 @@ void InitUnity(void);
 
 void UnityPostMessage(NSString* gameObject, NSString* methodName, NSString* message);
 
+void UnityPauseCommand();
+
+void UnityResumeCommand();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/ios/UnityUtils.mm
+++ b/ios/UnityUtils.mm
@@ -62,6 +62,20 @@ extern "C" void UnityPostMessage(NSString* gameObject, NSString* methodName, NSS
     UnitySendMessage([gameObject UTF8String], [methodName UTF8String], [message UTF8String]);
 }
 
+extern "C" void UnityPauseCommand()
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UnityPause(1);
+    });
+}
+
+extern "C" void UnityResumeCommand()
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UnityPause(0);
+    });
+}
+
 @implementation UnityUtils
 
 static NSHashTable* mUnityEventListeners = [NSHashTable weakObjectsHashTable];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,28 @@ export default class UnityView extends React.Component<UnityViewProps> {
     };
 
     /**
+     * Pause the unity player
+     */
+    public pause() {
+        UIManager.dispatchViewManagerCommand(
+            this.getViewHandle(),
+            UIManager.UnityView.Commands.pause,
+            []
+        );
+    };
+
+    /**
+     * Resume the unity player
+     */
+    public resume() {
+        UIManager.dispatchViewManagerCommand(
+            this.getViewHandle(),
+            UIManager.UnityView.Commands.resume,
+            []
+        );
+    };
+
+    /**
      * Send Message to UnityMessageManager.
      * @param message The message will post.
      */


### PR DESCRIPTION
When not showing the Unity View you might want to pause the Unity player so battery drain is minimalized. This pull request adds iOS and Android code to pause the player and updates the react UnityView to include a `pause` and `resume` function.